### PR TITLE
Kta 97 max retries limit

### DIFF
--- a/components/form/FirstStep.tsx
+++ b/components/form/FirstStep.tsx
@@ -1,6 +1,7 @@
 import { SubmitHandler } from 'react-hook-form';
 import type { SdkHandle } from 'onfido-sdk-ui';
 
+import { CONTACT_EMAIL } from '../../constants';
 import type ApplicantProperties from '../../types/ApplicantProperties';
 import CenteredCard from '../common/CenteredCard';
 import Header from '../layout/Header';
@@ -12,23 +13,31 @@ function FirstStep({
   onSubmit,
   loading,
   error,
+  hasReachedMaxRetries,
 }: {
   onfidoInstance: SdkHandle | null;
   onSubmit: SubmitHandler<ApplicantProperties>;
   loading: boolean;
   error: boolean;
+  hasReachedMaxRetries: boolean;
 }): JSX.Element {
   return onfidoInstance ? (
     <div />
   ) : (
     <CenteredCard>
       <Header />
-      <h3 className="mb-4">We want to get to know you!</h3>
-      <p>Start by introducing yourself here.</p>
-      <p>On the next page, we&apos;ll ask you to provide other information (documents or photos) that will help verify your identity.</p>
-      <p>Note: applicants younger than 18 years old will not be verified.</p>
+      {hasReachedMaxRetries ? (
+        <p className="text-secondary text-error-homepage">We could not verify your identity. Please contact support at {CONTACT_EMAIL}</p>
+      ) : (
+        <>
+          <h3 className="mb-4">We want to get to know you!</h3>
+          <p>Start by introducing yourself here.</p>
+          <p>On the next page, we&apos;ll ask you to provide other information (documents or photos) that will help verify your identity.</p>
+          <p>Note: applicants younger than 18 years old will not be verified.</p>
 
-      <ApplicantForm onSubmit={onSubmit} loading={loading} error={error} />
+          <ApplicantForm onSubmit={onSubmit} loading={loading} error={error} />
+        </>
+      )}
     </CenteredCard>
   );
 }

--- a/components/results/ResultsError.tsx
+++ b/components/results/ResultsError.tsx
@@ -5,7 +5,7 @@ import ResultsRetryButton from './ResultsRetryButton';
 export default function ResultsFailure({ kycEndpointKey, hasReachedMaxRetries }: { kycEndpointKey: string; hasReachedMaxRetries: boolean }): JSX.Element {
   return (
     <CenteredCardContent title="An error occurred" description="Sorry, an error occurred; we invite you to try again." iconClasses="fa fa-exclamation-circle text-warning mb-4">
-      <ResultsRetryButton kycEndpointKey={kycEndpointKey} hasReachedMaxRetries={hasReachedMaxRetries} />
+      {!hasReachedMaxRetries && <ResultsRetryButton kycEndpointKey={kycEndpointKey} />}
     </CenteredCardContent>
   );
 }

--- a/components/results/ResultsError.tsx
+++ b/components/results/ResultsError.tsx
@@ -2,10 +2,10 @@ import CenteredCardContent from '../common/CenteredCardContent';
 
 import ResultsRetryButton from './ResultsRetryButton';
 
-export default function ResultsFailure({ kycEndpointKey }: { kycEndpointKey: string }): JSX.Element {
+export default function ResultsFailure({ kycEndpointKey, hasReachedMaxRetries }: { kycEndpointKey: string; hasReachedMaxRetries: boolean }): JSX.Element {
   return (
     <CenteredCardContent title="An error occurred" description="Sorry, an error occurred; we invite you to try again." iconClasses="fa fa-exclamation-circle text-warning mb-4">
-      <ResultsRetryButton kycEndpointKey={kycEndpointKey} />
+      <ResultsRetryButton kycEndpointKey={kycEndpointKey} hasReachedMaxRetries={hasReachedMaxRetries} />
     </CenteredCardContent>
   );
 }

--- a/components/results/ResultsFailure.tsx
+++ b/components/results/ResultsFailure.tsx
@@ -1,3 +1,4 @@
+import { CONTACT_EMAIL } from '../../constants';
 import type ValidationFailure from '../../types/ValidationFailure';
 import validationMessages from '../../utils/validationMessages';
 import CenteredCardContent from '../common/CenteredCardContent';
@@ -20,7 +21,7 @@ export default function ResultsFailure({
       ? 'We could not verify your identity. If you believe that you submitted any information incorrectly, you may try again.'
       : 'We could not verify your identity. We invite you to read the reasons below and try again.';
 
-  description = hasReachedMaxRetries ? 'We could not verify your identity. Please contact support at hello@near.foundation' : description;
+  description = hasReachedMaxRetries ? `We could not verify your identity. Please contact support at ${CONTACT_EMAIL}` : description;
 
   return (
     <CenteredCardContent title="Verification failed" description={description} iconClasses="fa fa-times-circle text-danger mb-4">

--- a/components/results/ResultsFailure.tsx
+++ b/components/results/ResultsFailure.tsx
@@ -15,19 +15,25 @@ export default function ResultsFailure({
 }): JSX.Element {
   const EMPTY_ARRAY = 0;
 
-  const description =
+  let description =
     validationFailureDetails.length === EMPTY_ARRAY
       ? 'We could not verify your identity. If you believe that you submitted any information incorrectly, you may try again.'
       : 'We could not verify your identity. We invite you to read the reasons below and try again.';
 
+  description = hasReachedMaxRetries ? 'We could not verify your identity. Please contact support at hello@near.foundation' : description;
+
   return (
     <CenteredCardContent title="Verification failed" description={description} iconClasses="fa fa-times-circle text-danger mb-4">
-      <ul aria-label="error list" className="mb-4 text-dark fw-bold" style={{ textAlign: 'left' }}>
-        {validationFailureDetails.map((validationFailureDetail) => (
-          <li>{validationMessages.get(validationFailureDetail)}</li>
-        ))}
-      </ul>
-      <ResultsRetryButton kycEndpointKey={kycEndpointKey} hasReachedMaxRetries={hasReachedMaxRetries} />
+      {!hasReachedMaxRetries && (
+        <>
+          <ul aria-label="error list" className="mb-4 text-dark fw-bold" style={{ textAlign: 'left' }}>
+            {validationFailureDetails.map((validationFailureDetail) => (
+              <li>{validationMessages.get(validationFailureDetail)}</li>
+            ))}
+          </ul>
+          <ResultsRetryButton kycEndpointKey={kycEndpointKey} />
+        </>
+      )}
     </CenteredCardContent>
   );
 }

--- a/components/results/ResultsFailure.tsx
+++ b/components/results/ResultsFailure.tsx
@@ -4,7 +4,15 @@ import CenteredCardContent from '../common/CenteredCardContent';
 
 import ResultsRetryButton from './ResultsRetryButton';
 
-export default function ResultsFailure({ validationFailureDetails, kycEndpointKey }: { validationFailureDetails: ValidationFailure[]; kycEndpointKey: string }): JSX.Element {
+export default function ResultsFailure({
+  validationFailureDetails,
+  kycEndpointKey,
+  hasReachedMaxRetries,
+}: {
+  validationFailureDetails: ValidationFailure[];
+  kycEndpointKey: string;
+  hasReachedMaxRetries: boolean;
+}): JSX.Element {
   const EMPTY_ARRAY = 0;
 
   const description =
@@ -19,7 +27,7 @@ export default function ResultsFailure({ validationFailureDetails, kycEndpointKe
           <li>{validationMessages.get(validationFailureDetail)}</li>
         ))}
       </ul>
-      <ResultsRetryButton kycEndpointKey={kycEndpointKey} />
+      <ResultsRetryButton kycEndpointKey={kycEndpointKey} hasReachedMaxRetries={hasReachedMaxRetries} />
     </CenteredCardContent>
   );
 }

--- a/components/results/ResultsFailure.tsx
+++ b/components/results/ResultsFailure.tsx
@@ -26,7 +26,7 @@ export default function ResultsFailure({
     <CenteredCardContent title="Verification failed" description={description} iconClasses="fa fa-times-circle text-danger mb-4">
       {!hasReachedMaxRetries && (
         <>
-          <ul aria-label="error list" className="mb-4 text-dark fw-bold" style={{ textAlign: 'left' }}>
+          <ul aria-label="error list" className="mb-4 text-dark fw-bold error-list" style={{ textAlign: 'left' }}>
             {validationFailureDetails.map((validationFailureDetail) => (
               <li>{validationMessages.get(validationFailureDetail)}</li>
             ))}

--- a/components/results/ResultsRetryButton.tsx
+++ b/components/results/ResultsRetryButton.tsx
@@ -1,23 +1,7 @@
 import Link from 'next/link';
 
-export default function ResultsRetryButton({
-  autoRetry = true,
-  kycEndpointKey,
-  hasReachedMaxRetries,
-}: {
-  autoRetry?: boolean;
-  kycEndpointKey: string;
-  hasReachedMaxRetries: boolean;
-}): JSX.Element {
+export default function ResultsRetryButton({ autoRetry = true, kycEndpointKey }: { autoRetry?: boolean; kycEndpointKey: string }): JSX.Element {
   const link = autoRetry ? `/${kycEndpointKey}?retry=1` : `/${kycEndpointKey}`;
-
-  if (hasReachedMaxRetries) {
-    return (
-      <p>
-        We invite you to <a href="mailto:hello@near.foundation">contact the NEAR Foundation</a> for a manual verification
-      </p>
-    );
-  }
 
   return (
     <Link href={link} passHref>

--- a/components/results/ResultsRetryButton.tsx
+++ b/components/results/ResultsRetryButton.tsx
@@ -6,7 +6,7 @@ export default function ResultsRetryButton({ autoRetry = true, kycEndpointKey }:
   return (
     <Link href={link} passHref>
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-      <a className="btn btn-primary">
+      <a className="btn btn-primary btn-retry">
         Try again <i className="fa fa-repeat" aria-hidden="true" />
       </a>
     </Link>

--- a/components/results/ResultsRetryButton.tsx
+++ b/components/results/ResultsRetryButton.tsx
@@ -1,7 +1,23 @@
 import Link from 'next/link';
 
-export default function ResultsRetryButton({ autoRetry = true, kycEndpointKey }: { autoRetry?: boolean; kycEndpointKey: string }): JSX.Element {
+export default function ResultsRetryButton({
+  autoRetry = true,
+  kycEndpointKey,
+  hasReachedMaxRetries,
+}: {
+  autoRetry?: boolean;
+  kycEndpointKey: string;
+  hasReachedMaxRetries: boolean;
+}): JSX.Element {
   const link = autoRetry ? `/${kycEndpointKey}?retry=1` : `/${kycEndpointKey}`;
+
+  if (hasReachedMaxRetries) {
+    return (
+      <p>
+        We invite you to <a href="mailto:hello@near.foundation">contact the NEAR Foundation</a> for a manual verification
+      </p>
+    );
+  }
 
   return (
     <Link href={link} passHref>

--- a/constants/index.tsx
+++ b/constants/index.tsx
@@ -6,4 +6,4 @@ export const SHORT_POLLING_INTERVAL = 1000; // 1 second - Short polling applies 
 export const LONG_POLLING_INTERVAL = 30_000; // 30 seconds - Long polling applies when the check is under manual approval
 export const MIN_AGE_FOR_APPLICANT = 18;
 export const FORBIDDEN_CHARACTERS = '^!#$%*=<>;{}"'; // https://documentation.onfido.com/#forbidden-characters
-export const NUMBER_OF_RETRIES_ALLOWED = 3;
+export const MAX_NUMBER_OF_TRIES = 3;

--- a/constants/index.tsx
+++ b/constants/index.tsx
@@ -1,6 +1,6 @@
 export const COOKIES_EXPIRATION_TIME = 2592000; // 30 days
 export const COOKIE_CHECK_ID_NAME = 'onfido-check-id';
-export const COOKIE_NUMBER_OF_RETRIES_NAME = 'onfido-number-of-retries';
+export const COOKIE_NUMBER_OF_TRIES_NAME = 'onfido-number-of-tries';
 export const LOCALSTORAGE_USER_DATA_NAME = 'onfido-user-data';
 export const SHORT_POLLING_INTERVAL = 1000; // 1 second - Short polling applies when the check is in progress
 export const LONG_POLLING_INTERVAL = 30_000; // 30 seconds - Long polling applies when the check is under manual approval

--- a/constants/index.tsx
+++ b/constants/index.tsx
@@ -5,3 +5,4 @@ export const SHORT_POLLING_INTERVAL = 1000; // 1 second - Short polling applies 
 export const LONG_POLLING_INTERVAL = 30_000; // 30 seconds - Long polling applies when the check is under manual approval
 export const MIN_AGE_FOR_APPLICANT = 18;
 export const FORBIDDEN_CHARACTERS = '^!#$%*=<>;{}"'; // https://documentation.onfido.com/#forbidden-characters
+export const NUMBER_OF_RETRIES_ALLOWED = 3;

--- a/constants/index.tsx
+++ b/constants/index.tsx
@@ -1,5 +1,6 @@
 export const COOKIES_EXPIRATION_TIME = 2592000; // 30 days
 export const COOKIE_CHECK_ID_NAME = 'onfido-check-id';
+export const COOKIE_NUMBER_OF_RETRIES_NAME = 'onfido-number-of-retries';
 export const LOCALSTORAGE_USER_DATA_NAME = 'onfido-user-data';
 export const SHORT_POLLING_INTERVAL = 1000; // 1 second - Short polling applies when the check is in progress
 export const LONG_POLLING_INTERVAL = 30_000; // 30 seconds - Long polling applies when the check is under manual approval

--- a/constants/index.tsx
+++ b/constants/index.tsx
@@ -7,3 +7,4 @@ export const LONG_POLLING_INTERVAL = 30_000; // 30 seconds - Long polling applie
 export const MIN_AGE_FOR_APPLICANT = 18;
 export const FORBIDDEN_CHARACTERS = '^!#$%*=<>;{}"'; // https://documentation.onfido.com/#forbidden-characters
 export const MAX_NUMBER_OF_TRIES = 3;
+export const CONTACT_EMAIL = 'hello@near.foundation';

--- a/pages/api/generate-token.ts
+++ b/pages/api/generate-token.ts
@@ -2,11 +2,11 @@
 import { OnfidoApiError } from '@onfido/api';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-import { COOKIE_NUMBER_OF_TRIES_NAME, COOKIES_EXPIRATION_TIME } from '../../constants';
+import { COOKIE_NUMBER_OF_TRIES_NAME, COOKIES_EXPIRATION_TIME, MAX_NUMBER_OF_TRIES } from '../../constants';
 import getOnfido from '../../helpers/onfido';
 import type ApplicantProperties from '../../types/ApplicantProperties';
 import type ApplicantTokenPair from '../../types/ApplicantTokenPair';
-import { SERVER_ERROR, SUCCESS } from '../../utils/statusCodes';
+import { FORBIDDEN, SERVER_ERROR, SUCCESS } from '../../utils/statusCodes';
 
 const endpointName = 'generate-token';
 
@@ -68,6 +68,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const applicant = await onfido.applicant.create(applicantProperties);
 
     console.log('Applicant created', endpointName);
+    const ZERO = '0';
+    const ONE = 1;
+    const numberOfTriesString = req.cookies[COOKIE_NUMBER_OF_TRIES_NAME] ?? ZERO;
+    const numberOfTries = parseInt(numberOfTriesString, 10);
+
+    if (numberOfTries >= MAX_NUMBER_OF_TRIES) {
+      res.status(FORBIDDEN).json({ error: 'Maximum number of tries reached' });
+      return;
+    }
 
     const sdkToken = await onfido.sdkToken.generate({
       applicantId: applicant.id,
@@ -75,11 +84,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       // crossDeviceUrl: "https://example.com"
     });
     const result = { applicantId: applicant.id, sdkToken };
+    const newNumberOfTries = numberOfTries + ONE;
 
-    const ZERO = '0';
-    const ONE = 1;
-    const numberOfTries = req.cookies[COOKIE_NUMBER_OF_TRIES_NAME] ?? ZERO;
-    const newNumberOfTries = parseInt(numberOfTries, 10) + ONE;
     res.setHeader('Set-Cookie', [`${COOKIE_NUMBER_OF_TRIES_NAME}=${newNumberOfTries}; Path=/; Max-Age=${COOKIES_EXPIRATION_TIME}`]);
 
     console.log('Returning result', endpointName);

--- a/pages/api/generate-token.ts
+++ b/pages/api/generate-token.ts
@@ -74,7 +74,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const numberOfTries = parseInt(numberOfTriesString, 10);
 
     if (numberOfTries >= MAX_NUMBER_OF_TRIES) {
-      res.status(FORBIDDEN).json({ status: 'Maximum number of tries reached' });
+      res.status(FORBIDDEN).json({ status: 'Maximum number of tries reached', code: FORBIDDEN });
       return;
     }
 

--- a/pages/api/generate-token.ts
+++ b/pages/api/generate-token.ts
@@ -2,6 +2,7 @@
 import { OnfidoApiError } from '@onfido/api';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+import { COOKIE_NUMBER_OF_TRIES_NAME, COOKIES_EXPIRATION_TIME } from '../../constants';
 import getOnfido from '../../helpers/onfido';
 import type ApplicantProperties from '../../types/ApplicantProperties';
 import type ApplicantTokenPair from '../../types/ApplicantTokenPair';
@@ -74,6 +75,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       // crossDeviceUrl: "https://example.com"
     });
     const result = { applicantId: applicant.id, sdkToken };
+
+    const ZERO = '0';
+    const ONE = 1;
+    const numberOfTries = req.cookies[COOKIE_NUMBER_OF_TRIES_NAME] ?? ZERO;
+    const newNumberOfTries = parseInt(numberOfTries, 10) + ONE;
+    res.setHeader('Set-Cookie', [`${COOKIE_NUMBER_OF_TRIES_NAME}=${newNumberOfTries}; Path=/; Max-Age=${COOKIES_EXPIRATION_TIME}`]);
 
     console.log('Returning result', endpointName);
     res.status(SUCCESS).json(result);

--- a/pages/api/generate-token.ts
+++ b/pages/api/generate-token.ts
@@ -74,7 +74,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const numberOfTries = parseInt(numberOfTriesString, 10);
 
     if (numberOfTries >= MAX_NUMBER_OF_TRIES) {
-      res.status(FORBIDDEN).json({ error: 'Maximum number of tries reached' });
+      res.status(FORBIDDEN).json({ status: 'Maximum number of tries reached' });
       return;
     }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import CenteredCard from '../components/common/CenteredCard';
 import Header from '../components/layout/Header';
 import MainLayout from '../components/layout/MainLayout';
+import { CONTACT_EMAIL } from '../constants';
 
 function Index() {
   return (
@@ -9,7 +10,7 @@ function Index() {
         <Header />
         <div className="first-step" style={{ maxWidth: '750px' }}>
           <p>
-            If you are looking for the KYC Form we invite you to <a href="mailto:hello@near.foundation">contact the NEAR Foundation</a>.
+            If you are looking for the KYC Form we invite you to <a href={`mailto:${CONTACT_EMAIL}`}>contact the NEAR Foundation</a>.
           </p>
         </div>
       </CenteredCard>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ import * as dotenv from 'dotenv';
  */
 dotenv.config();
 
-const MAXIMUM_TIME_PER_TEST_IN_MILLISECONDS = 60_000;
+const MAXIMUM_TIME_PER_TEST_IN_MILLISECONDS = 120_000;
 const MAXIMUM_TIME_TO_WAIT_FOR_CONDITION_IN_MILLISECONDS = 10_000;
 
 /**

--- a/tests/e2e/api-generate-tokens.spec.ts
+++ b/tests/e2e/api-generate-tokens.spec.ts
@@ -11,6 +11,8 @@ import { API_URL, FLOW_URL } from './utils/constants';
 let desktop: BrowserContext;
 let applicant: ApplicantProperties;
 
+const ZERO = 0;
+
 test.beforeEach(async ({ browser }) => {
   desktop = await browser.newContext({
     permissions: ['clipboard-write', 'clipboard-read'],
@@ -30,9 +32,8 @@ test('/api/generate-token should return 403 if the applicant has reached the ret
   // eslint-disable-next-line no-underscore-dangle
   const csrfToken = await desktopPage.evaluate(() => window.__NEXT_DATA__.props.pageProps.csrfToken);
 
-  // refactor this to a loop
-
-  for (let i = 0; i < MAX_NUMBER_OF_TRIES; i++) {
+  // eslint-disable-next-line no-plusplus
+  for (let i = ZERO; i < MAX_NUMBER_OF_TRIES; i++) {
     const response = await desktopPage.request.post(`${API_URL}/generate-token`, {
       data: {
         ...applicant,

--- a/tests/e2e/api-generate-tokens.spec.ts
+++ b/tests/e2e/api-generate-tokens.spec.ts
@@ -1,0 +1,76 @@
+import { faker } from '@faker-js/faker';
+import { BrowserContext, expect, test } from '@playwright/test';
+
+import type ApplicantProperties from '../../types/ApplicantProperties';
+import { FORBIDDEN, SUCCESS } from '../../utils/statusCodes';
+
+import { API_URL, FLOW_URL } from './utils/constants';
+
+let desktop: BrowserContext;
+let applicant: ApplicantProperties;
+
+test.beforeEach(async ({ browser }) => {
+  desktop = await browser.newContext({
+    permissions: ['clipboard-write', 'clipboard-read'],
+  });
+
+  applicant = {
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+    email: faker.internet.email(),
+    dob: faker.date.birthdate({ min: 18, max: 65, mode: 'age' }).toISOString().split('T')[0],
+  };
+});
+
+test('/api/generate-token should return 403 if the applicant has reached the retry limit', async () => {
+  const desktopPage = await desktop.newPage();
+  await desktopPage.goto(FLOW_URL);
+  // eslint-disable-next-line no-underscore-dangle
+  const csrfToken = await desktopPage.evaluate(() => window.__NEXT_DATA__.props.pageProps.csrfToken);
+
+  const responseTry1 = await desktopPage.request.post(`${API_URL}/generate-token`, {
+    data: {
+      ...applicant,
+      csrf_token: csrfToken,
+    },
+  });
+
+  await expect(responseTry1.status()).toEqual(SUCCESS);
+  await expect(await responseTry1.json()).toHaveProperty('applicantId');
+  await expect(await responseTry1.json()).toHaveProperty('sdkToken');
+
+  const responseTry2 = await desktopPage.request.post(`${API_URL}/generate-token`, {
+    data: {
+      ...applicant,
+      csrf_token: csrfToken,
+    },
+  });
+
+  await expect(responseTry2.status()).toEqual(SUCCESS);
+  await expect(await responseTry2.json()).toHaveProperty('applicantId');
+  await expect(await responseTry2.json()).toHaveProperty('sdkToken');
+
+  const responseTry3 = await desktopPage.request.post(`${API_URL}/generate-token`, {
+    data: {
+      ...applicant,
+      csrf_token: csrfToken,
+    },
+  });
+
+  await expect(responseTry3.status()).toEqual(SUCCESS);
+  await expect(await responseTry3.json()).toHaveProperty('applicantId');
+  await expect(await responseTry3.json()).toHaveProperty('sdkToken');
+
+  const responseTry4 = await desktopPage.request.post(`${API_URL}/generate-token`, {
+    data: {
+      ...applicant,
+      csrf_token: csrfToken,
+    },
+  });
+
+  await expect(responseTry4.status()).toEqual(FORBIDDEN);
+  const { code, status } = await responseTry4.json();
+
+  expect(code).toBe(FORBIDDEN);
+  expect(status).toBe('Maximum number of tries reached');
+});

--- a/tests/e2e/retries-limitations.spec.ts
+++ b/tests/e2e/retries-limitations.spec.ts
@@ -4,7 +4,7 @@ import { Browser, BrowserContext, chromium, expect, test } from '@playwright/tes
 import { CONTACT_EMAIL } from '../../constants';
 import type ApplicantProperties from '../../types/ApplicantProperties';
 
-import { MOCK_VIDEO_PATH } from './utils/constants';
+import { FLOW_URL, MOCK_VIDEO_PATH } from './utils/constants';
 import { continueOnfidoFlowThenGetAndTestLink, fillStartForm, openKycLinkAndTestDocumentAndPhotoScan, submittingDocuments } from './utils/helpers';
 
 const ZERO = 0;
@@ -39,6 +39,7 @@ test.beforeEach(async ({ browser }) => {
 test('Applicant should not be able to retry more than the maximum set up', async () => {
   const desktopPage = await desktop.newPage();
 
+  // First try
   await fillStartForm(desktopPage, { ...applicant, lastName: 'consider' });
   const url = await continueOnfidoFlowThenGetAndTestLink(desktopPage, expect);
 
@@ -78,4 +79,12 @@ test('Applicant should not be able to retry more than the maximum set up', async
   await expect(await desktopPage.locator('.error-list').count()).toEqual(ZERO);
 
   await desktopPage.screenshot({ path: 'tests/e2e/screenshots/failed_third_time.png', fullPage: true });
+
+  // Going to homepage and checking that there is an error message
+  await desktopPage.goto(FLOW_URL);
+  await expect(desktopPage.getByText(/We could not verify your identity. Please contact support at /)).toHaveText(
+    `We could not verify your identity. Please contact support at ${CONTACT_EMAIL}`,
+  );
+
+  await desktopPage.screenshot({ path: 'tests/e2e/screenshots/homepage_after_failing.png', fullPage: true });
 });

--- a/tests/e2e/retries-limitations.spec.ts
+++ b/tests/e2e/retries-limitations.spec.ts
@@ -67,7 +67,10 @@ test('Applicant should not be able to retry more than the maximum set up', async
   await openKycLinkAndTestDocumentAndPhotoScan(urlThirdTry, mobilePageThirdTry, expect);
 
   await submittingDocuments(desktopPage);
-  await desktopPage.pause(); // to replace by the check of the max retries reached message
   await expect(desktopPage.getByRole('heading', { name: /Verification/i })).toHaveText('Verification failed');
+  await expect(desktopPage.getByText(/We could not verify your identity. Please contact support at hello@near.foundation/)).toHaveText(
+    'We could not verify your identity. Please contact support at hello@near.foundation',
+  );
+
   await desktopPage.screenshot({ path: 'tests/e2e/screenshots/failed_third_time.png', fullPage: true });
 });

--- a/tests/e2e/retries-limitations.spec.ts
+++ b/tests/e2e/retries-limitations.spec.ts
@@ -1,11 +1,10 @@
 import { faker } from '@faker-js/faker';
 import { Browser, BrowserContext, chromium, expect, test } from '@playwright/test';
 
-import { CONTACT_EMAIL, COOKIE_NUMBER_OF_TRIES_NAME } from '../../constants';
+import { CONTACT_EMAIL } from '../../constants';
 import type ApplicantProperties from '../../types/ApplicantProperties';
-import { FORBIDDEN, SUCCESS } from '../../utils/statusCodes';
 
-import { API_URL, FLOW_URL, MOCK_VIDEO_PATH } from './utils/constants';
+import { MOCK_VIDEO_PATH } from './utils/constants';
 import { continueOnfidoFlowThenGetAndTestLink, fillStartForm, openKycLinkAndTestDocumentAndPhotoScan, submittingDocuments } from './utils/helpers';
 
 const ZERO = 0;
@@ -79,57 +78,4 @@ test('Applicant should not be able to retry more than the maximum set up', async
   await expect(await desktopPage.locator('.error-list').count()).toEqual(ZERO);
 
   await desktopPage.screenshot({ path: 'tests/e2e/screenshots/failed_third_time.png', fullPage: true });
-});
-
-test('/api/generate-token should return 403 if the applicant has reached the retry limit', async () => {
-  const desktopPage = await desktop.newPage();
-  await desktopPage.goto(FLOW_URL);
-  // eslint-disable-next-line no-underscore-dangle
-  const csrfToken = await desktopPage.evaluate(() => window.__NEXT_DATA__.props.pageProps.csrfToken);
-
-  const responseTry1 = await desktopPage.request.post(`${API_URL}/generate-token`, {
-    data: {
-      ...applicant,
-      csrf_token: csrfToken,
-    },
-  });
-
-  await expect(responseTry1.status()).toEqual(SUCCESS);
-  await expect(await responseTry1.json()).toHaveProperty('applicantId');
-  await expect(await responseTry1.json()).toHaveProperty('sdkToken');
-
-  const responseTry2 = await desktopPage.request.post(`${API_URL}/generate-token`, {
-    data: {
-      ...applicant,
-      csrf_token: csrfToken,
-    },
-  });
-
-  await expect(responseTry2.status()).toEqual(SUCCESS);
-  await expect(await responseTry2.json()).toHaveProperty('applicantId');
-  await expect(await responseTry2.json()).toHaveProperty('sdkToken');
-
-  const responseTry3 = await desktopPage.request.post(`${API_URL}/generate-token`, {
-    data: {
-      ...applicant,
-      csrf_token: csrfToken,
-    },
-  });
-
-  await expect(responseTry3.status()).toEqual(SUCCESS);
-  await expect(await responseTry3.json()).toHaveProperty('applicantId');
-  await expect(await responseTry3.json()).toHaveProperty('sdkToken');
-
-  const responseTry4 = await desktopPage.request.post(`${API_URL}/generate-token`, {
-    data: {
-      ...applicant,
-      csrf_token: csrfToken,
-    },
-  });
-
-  await expect(responseTry4.status()).toEqual(FORBIDDEN);
-  const { code, status } = await responseTry4.json();
-
-  expect(code).toBe(FORBIDDEN);
-  expect(status).toBe('Maximum number of tries reached');
 });

--- a/tests/e2e/retries-limitations.spec.ts
+++ b/tests/e2e/retries-limitations.spec.ts
@@ -1,0 +1,73 @@
+import { faker } from '@faker-js/faker';
+import { Browser, BrowserContext, chromium, expect, test } from '@playwright/test';
+
+import type ApplicantProperties from '../../types/ApplicantProperties';
+
+import { MOCK_VIDEO_PATH } from './utils/constants';
+import { continueOnfidoFlowThenGetAndTestLink, fillStartForm, openKycLinkAndTestDocumentAndPhotoScan, submittingDocuments } from './utils/helpers';
+
+let browserWithMockedWebcam: Browser;
+let desktop: BrowserContext;
+let mobile: BrowserContext;
+let applicant: ApplicantProperties;
+
+test.beforeEach(async ({ browser }) => {
+  browserWithMockedWebcam = await chromium.launch({
+    args: ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream', `--use-file-for-fake-video-capture=${MOCK_VIDEO_PATH}`],
+  });
+
+  desktop = await browser.newContext({
+    permissions: ['clipboard-write', 'clipboard-read'],
+  });
+
+  mobile = await browserWithMockedWebcam.newContext({
+    userAgent: 'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.5249.126 Mobile Safari/537.36',
+    permissions: ['camera'],
+  });
+
+  applicant = {
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+    email: faker.internet.email(),
+    dob: faker.date.birthdate({ min: 18, max: 65, mode: 'age' }).toISOString().split('T')[0],
+  };
+});
+
+test('Applicant should not be able to retry more than the maximum set up', async () => {
+  const desktopPage = await desktop.newPage();
+
+  await fillStartForm(desktopPage, { ...applicant, lastName: 'consider' });
+  const url = await continueOnfidoFlowThenGetAndTestLink(desktopPage, expect);
+
+  const mobilePage = await mobile.newPage();
+  await openKycLinkAndTestDocumentAndPhotoScan(url, mobilePage, expect);
+
+  await submittingDocuments(desktopPage);
+  await expect(desktopPage.getByRole('heading', { name: /Verification/i })).toHaveText('Verification failed');
+
+  await desktopPage.getByRole('link', { name: 'Try again' }).click();
+  await expect(desktopPage.getByText(/Verify your identity/i)).toHaveText('Verify your identity');
+
+  // Second try
+  const urlSecondTry = await continueOnfidoFlowThenGetAndTestLink(desktopPage, expect);
+
+  const mobilePageSecondTry = await mobile.newPage();
+  await openKycLinkAndTestDocumentAndPhotoScan(urlSecondTry, mobilePageSecondTry, expect);
+
+  await submittingDocuments(desktopPage);
+  await expect(desktopPage.getByRole('heading', { name: /Verification/i })).toHaveText('Verification failed');
+
+  await desktopPage.getByRole('link', { name: 'Try again' }).click();
+  await expect(desktopPage.getByText(/Verify your identity/i)).toHaveText('Verify your identity');
+
+  // Third and last try
+  const urlThirdTry = await continueOnfidoFlowThenGetAndTestLink(desktopPage, expect);
+
+  const mobilePageThirdTry = await mobile.newPage();
+  await openKycLinkAndTestDocumentAndPhotoScan(urlThirdTry, mobilePageThirdTry, expect);
+
+  await submittingDocuments(desktopPage);
+  await desktopPage.pause(); // to replace by the check of the max retries reached message
+  await expect(desktopPage.getByRole('heading', { name: /Verification/i })).toHaveText('Verification failed');
+  await desktopPage.screenshot({ path: 'tests/e2e/screenshots/failed_third_time.png', fullPage: true });
+});

--- a/tests/e2e/retries-limitations.spec.ts
+++ b/tests/e2e/retries-limitations.spec.ts
@@ -81,8 +81,7 @@ test('Applicant should not be able to retry more than the maximum set up', async
   await desktopPage.screenshot({ path: 'tests/e2e/screenshots/failed_third_time.png', fullPage: true });
 });
 
-// TODO FIX THIS TEST
-test('/api/generate-token should return 403 if the applicant has reached the retry limit', async ({ request }) => {
+test('/api/generate-token should return 403 if the applicant has reached the retry limit', async () => {
   const cookies = [
     {
       name: COOKIE_NUMBER_OF_TRIES_NAME,
@@ -98,17 +97,15 @@ test('/api/generate-token should return 403 if the applicant has reached the ret
   // eslint-disable-next-line no-underscore-dangle
   const csrfToken = await desktopPage.evaluate(() => window.__NEXT_DATA__.props.pageProps.csrfToken);
 
-  const response = await request.post(`${API_URL}/generate-token`, {
+  const response = await desktopPage.request.post(`${API_URL}/generate-token`, {
     data: {
       ...applicant,
       csrf_token: csrfToken,
     },
   });
 
-  console.log(response);
+  const { code, status } = await response.json();
 
-  const data = await response.json();
-
-  expect(data.code).toBe(FORBIDDEN);
-  expect(data.status).toBe('Maximum number of tries reached');
+  expect(code).toBe(FORBIDDEN);
+  expect(status).toBe('Maximum number of tries reached');
 });

--- a/tests/e2e/retries-limitations.spec.ts
+++ b/tests/e2e/retries-limitations.spec.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { Browser, BrowserContext, chromium, expect, test } from '@playwright/test';
 
+import { CONTACT_EMAIL } from '../../constants';
 import type ApplicantProperties from '../../types/ApplicantProperties';
 
 import { MOCK_VIDEO_PATH } from './utils/constants';
@@ -70,8 +71,8 @@ test('Applicant should not be able to retry more than the maximum set up', async
 
   await submittingDocuments(desktopPage);
   await expect(desktopPage.getByRole('heading', { name: /Verification/i })).toHaveText('Verification failed');
-  await expect(desktopPage.getByText(/We could not verify your identity. Please contact support at hello@near.foundation/)).toHaveText(
-    'We could not verify your identity. Please contact support at hello@near.foundation',
+  await expect(desktopPage.getByText(/We could not verify your identity. Please contact support at /)).toHaveText(
+    `We could not verify your identity. Please contact support at ${CONTACT_EMAIL}`,
   );
   await expect(await desktopPage.locator('.btn-retry').count()).toEqual(ZERO);
   await expect(await desktopPage.locator('.error-list').count()).toEqual(ZERO);

--- a/tests/e2e/retries-limitations.spec.ts
+++ b/tests/e2e/retries-limitations.spec.ts
@@ -6,6 +6,8 @@ import type ApplicantProperties from '../../types/ApplicantProperties';
 import { MOCK_VIDEO_PATH } from './utils/constants';
 import { continueOnfidoFlowThenGetAndTestLink, fillStartForm, openKycLinkAndTestDocumentAndPhotoScan, submittingDocuments } from './utils/helpers';
 
+const ZERO = 0;
+
 let browserWithMockedWebcam: Browser;
 let desktop: BrowserContext;
 let mobile: BrowserContext;
@@ -71,6 +73,8 @@ test('Applicant should not be able to retry more than the maximum set up', async
   await expect(desktopPage.getByText(/We could not verify your identity. Please contact support at hello@near.foundation/)).toHaveText(
     'We could not verify your identity. Please contact support at hello@near.foundation',
   );
+  await expect(await desktopPage.locator('.btn-retry').count()).toEqual(ZERO);
+  await expect(await desktopPage.locator('.error-list').count()).toEqual(ZERO);
 
   await desktopPage.screenshot({ path: 'tests/e2e/screenshots/failed_third_time.png', fullPage: true });
 });

--- a/tests/e2e/retries-limitations.spec.ts
+++ b/tests/e2e/retries-limitations.spec.ts
@@ -3,7 +3,7 @@ import { Browser, BrowserContext, chromium, expect, test } from '@playwright/tes
 
 import { CONTACT_EMAIL, COOKIE_NUMBER_OF_TRIES_NAME } from '../../constants';
 import type ApplicantProperties from '../../types/ApplicantProperties';
-import { FORBIDDEN } from '../../utils/statusCodes';
+import { FORBIDDEN, SUCCESS } from '../../utils/statusCodes';
 
 import { API_URL, FLOW_URL, MOCK_VIDEO_PATH } from './utils/constants';
 import { continueOnfidoFlowThenGetAndTestLink, fillStartForm, openKycLinkAndTestDocumentAndPhotoScan, submittingDocuments } from './utils/helpers';
@@ -82,29 +82,53 @@ test('Applicant should not be able to retry more than the maximum set up', async
 });
 
 test('/api/generate-token should return 403 if the applicant has reached the retry limit', async () => {
-  const cookies = [
-    {
-      name: COOKIE_NUMBER_OF_TRIES_NAME,
-      value: '3',
-      domain: 'localhost',
-      path: '/',
-    },
-  ];
-  desktop.addCookies(cookies);
-
   const desktopPage = await desktop.newPage();
   await desktopPage.goto(FLOW_URL);
   // eslint-disable-next-line no-underscore-dangle
   const csrfToken = await desktopPage.evaluate(() => window.__NEXT_DATA__.props.pageProps.csrfToken);
 
-  const response = await desktopPage.request.post(`${API_URL}/generate-token`, {
+  const responseTry1 = await desktopPage.request.post(`${API_URL}/generate-token`, {
     data: {
       ...applicant,
       csrf_token: csrfToken,
     },
   });
 
-  const { code, status } = await response.json();
+  await expect(responseTry1.status()).toEqual(SUCCESS);
+  await expect(await responseTry1.json()).toHaveProperty('applicantId');
+  await expect(await responseTry1.json()).toHaveProperty('sdkToken');
+
+  const responseTry2 = await desktopPage.request.post(`${API_URL}/generate-token`, {
+    data: {
+      ...applicant,
+      csrf_token: csrfToken,
+    },
+  });
+
+  await expect(responseTry2.status()).toEqual(SUCCESS);
+  await expect(await responseTry2.json()).toHaveProperty('applicantId');
+  await expect(await responseTry2.json()).toHaveProperty('sdkToken');
+
+  const responseTry3 = await desktopPage.request.post(`${API_URL}/generate-token`, {
+    data: {
+      ...applicant,
+      csrf_token: csrfToken,
+    },
+  });
+
+  await expect(responseTry3.status()).toEqual(SUCCESS);
+  await expect(await responseTry3.json()).toHaveProperty('applicantId');
+  await expect(await responseTry3.json()).toHaveProperty('sdkToken');
+
+  const responseTry4 = await desktopPage.request.post(`${API_URL}/generate-token`, {
+    data: {
+      ...applicant,
+      csrf_token: csrfToken,
+    },
+  });
+
+  await expect(responseTry4.status()).toEqual(FORBIDDEN);
+  const { code, status } = await responseTry4.json();
 
   expect(code).toBe(FORBIDDEN);
   expect(status).toBe('Maximum number of tries reached');

--- a/tests/e2e/utils/constants.ts
+++ b/tests/e2e/utils/constants.ts
@@ -4,3 +4,4 @@ export const MOCK_VIDEO_PATH = path.join(__dirname, '../assets/camera.mjpeg');
 export const MOCK_IMAGE = 'tests/e2e/assets/id-card.jpg';
 export const FLOW_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/${process.env.KYC_ENDPOINT_KEY}`;
 export const HOME_URL = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
+export const API_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/api`;


### PR DESCRIPTION
What I implemented:
- The retry button disappears at the 3rd trial
- You see a message at the 3rd trial asking to restart
- The API endpoint to create a check is protected
- The form page contains the same error message

## Third trial message
![failed_third_time](https://user-images.githubusercontent.com/3635348/204841686-fc76e0c0-8a47-417e-ae10-f6ea49d70c4e.png)

## Message in the form page
![homepage_after_failing](https://user-images.githubusercontent.com/3635348/204842271-43015f11-dbba-42f2-aad3-066ff0c7c954.png)

